### PR TITLE
Stacked Bar

### DIFF
--- a/src/components/charts/StackedBar.jsx
+++ b/src/components/charts/StackedBar.jsx
@@ -1,0 +1,97 @@
+import { useMemo } from "react";
+import Plot from "react-plotly.js";
+import useAppStore from "../../store/AppStore";
+import useUserStore from "../../store/UserStore";
+
+const levels = ["Low", "Moderate", "High", "Very High"];
+const colors = {
+  Low: "green",
+  Moderate: "yellow",
+  High: "red",
+  "Very High": "black",
+};
+
+const class_height = {
+  Low: 1,
+  Moderate: 2,
+  High: 3,
+  "Very High": 4,
+};
+
+const StackedBarChart = () => {
+  const selectedEngineIds = useAppStore((state) => state.selectedEngineIds);
+  const { emissions } = useUserStore();
+
+  const traces = useMemo(() => {
+    const tracesByLevel = levels.map((level) => ({
+      name: level,
+      x: [],
+      y: [],
+      customdata: [],
+      type: "bar",
+      marker: { color: colors[level] },
+      hovertemplate:
+        "%{x}<br>" +
+        "Level: %{fullData.name}<br>" +
+        "Confidence: %{customdata:.0%}<extra></extra>",
+    }));
+  
+    selectedEngineIds.forEach((engineId) => {
+      const prediction = emissions[engineId]?.predictions;
+      if (!prediction) return;
+  
+      ["CO", "NOX"].forEach((pollutant) => {
+        const label = `${engineId}-${pollutant}`;
+        const pollutantData = prediction[pollutant];
+  
+        if (!pollutantData?.Class || !pollutantData?.Confidence) return;
+  
+        const totalHeight = class_height[pollutantData.Class] || 0;
+        levels.forEach((level, index) => {
+          const conf = pollutantData.Confidence[level] || 0;
+          const height = conf * totalHeight;
+          tracesByLevel[index].x.push(label);
+          tracesByLevel[index].y.push(height);
+          tracesByLevel[index].customdata.push(conf);
+        });
+      });
+    });
+  
+    return tracesByLevel;
+  }, [selectedEngineIds, emissions]);
+  
+  return (
+    <div className="w-full max-w-4xl mx-auto">
+      <h3 className="font-bold text-center text-xl mb-4">Stacked Emission Severity Chart</h3>
+      <Plot
+        data={traces}
+        layout={{
+          barmode: "stack",
+          dragmode: false,
+          xaxis: {
+            tickangle: 0,
+          },
+          yaxis: {
+            tickmode: "array",
+            tickvals: [1, 2, 3, 4],
+            ticktext: ["Low", "Moderate", "High", "Very High"],
+            range: [0, 4],
+          },
+          legend: { orientation: "h" },
+          margin: { t: 20, b: 80, l: 80, r: 20 },
+          autosize: true,
+          paper_bgcolor: "transparent",
+          plot_bgcolor: "transparent",
+        }}
+        useResizeHandler
+        style={{ width: "100%", height: "100%" }}
+        config={{
+          responsive: true,
+          displayModeBar: false,
+        }}
+      />
+    </div>
+  );
+};
+
+export default StackedBarChart;

--- a/src/pages/ComparePage.jsx
+++ b/src/pages/ComparePage.jsx
@@ -1,9 +1,27 @@
 import Template from "../Template";
+import CSS from "./EnginePage.module.css";
 import "../components/ParameterCard";
+import useAppStore from "../store/AppStore";
+import StackedBar from "../components/charts/StackedBar"
+
 
 const ComparePage = () => {
+    const selectedEngineIds = useAppStore((state) => state.selectedEngineIds);
+    console.log(selectedEngineIds);
+
     return (
-        <Template />
+        <Template>
+            <div className="flex flex-col w-full items-center gap-8">
+            <h2 className="font-bold text-center font-[Inter] text-3xl mt-[50px] whitespace-pre-line">{`Compare\n${selectedEngineIds.join(', ')}`}</h2>
+                <div className="flex flex-col w-full items-center">
+                    <div className="flex flex-col w-full">
+                        <div className={`${CSS.container} min-h-[530px] h-[530px]`}>
+                            <StackedBar/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Template>
     );
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/267cea4a-9d5a-40ab-a033-f82169cebec4)

![image](https://github.com/user-attachments/assets/50d6fc06-9031-4cb9-8821-960e1d0cfb73)

Colors represent the Class, From Green being low, to very high being black. The Confidence values are shown as a Percentage of the graph. The primary issue I ran into was how the chart renders the confidence values. As it is, and the best/ easiest solution, the Classifications are set from Low, Moderate, High, and Very High. They're also set to 1, 2, 3, and 4. This means that while technically, the Y-axis shows the Classifications, they're also a numerical value for how tall the bar will be. This is fine, but the only issue was that I would have to multiply the Confidence values by whatever number the class is set to. This is easily fixed, however, by simply showing either the original values or a percentage when hovering over the bar. 